### PR TITLE
Changes to Run Examples As Is

### DIFF
--- a/showcase/index.html
+++ b/showcase/index.html
@@ -24,8 +24,12 @@
   // Setting the environment dynamically
   // IMPORTANT Make sure you replace the client ID at the end with your own and the redirect URI with the one you submitted in the I.AM
   // Connect documentation
-  const keycloak = getKeycloakConfigurationForEnv();
-  keycloak.init({onLoad: 'login-required', checkLoginIframe: false}).then(function (authenticated) {
+  const keycloak = getKeycloakConfigurationForEnv('https://api-acpt.ehealth.fgov.be/auth', 'healthcare', 'myClientId');
+  keycloak.init({
+    onLoad: 'login-required',
+    redirectUri: 'http://myredirecturi.com',
+    checkLoginIframe: false
+  }).then(function (authenticated) {
     // Initialization of the authentication library
     // Creation of the custom element
     const create = document.createElement('nihdi-referral-prescription-create');
@@ -50,7 +54,7 @@
     alert('failed to initialize');
   });
 
-  function getKeycloakConfigurationForEnv() {
+  function getKeycloakConfigurationForEnv(authorization_server_url, realm_name, client_id) {
     return new Keycloak({
       url: `${authorization_server_url}`,
       realm: `${realm_name}`,

--- a/showcase/index.html
+++ b/showcase/index.html
@@ -7,7 +7,7 @@
   <title>Testing the News Web Component</title>
   <base href="/">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <link rel="stylesheet" href="web-components/create-prescription/wc-create-prescription.css">
+  <link rel="stylesheet" href="https://wwwacc.referral-prescription.in.ehealth.fgov.be/web-components/create-prescription/wc-create-prescription.css">
   <script src="web-components/create-prescription/keycloak.js"></script>
   <style>
     body {
@@ -55,6 +55,6 @@
 </script>
 
 <!-- Web component script at the end -->
-<script src="web-components/create-prescription/wc-create-prescription.js" type="module"></script>
+<script src="https://wwwacc.referral-prescription.in.ehealth.fgov.be/web-components/create-prescription/wc-create-prescription.js" type="module"></script>
 </body>
 </html>

--- a/showcase/index.html
+++ b/showcase/index.html
@@ -8,7 +8,10 @@
   <base href="/">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="stylesheet" href="https://wwwacc.referral-prescription.in.ehealth.fgov.be/web-components/create-prescription/wc-create-prescription.css">
-  <script src="web-components/create-prescription/keycloak.js"></script>
+  
+  <!-- Required packages -->
+  <script src="https://cdn.jsdelivr.net/npm/keycloak-js@25.0.6/dist/keycloak.min.js"></script>
+  
   <style>
     body {
       font-family: Roboto, "Helvetica Neue", sans-serif;

--- a/showcase/index.html
+++ b/showcase/index.html
@@ -21,28 +21,30 @@
 <body>
 <script>
   const params = new URLSearchParams(window.location.search);
-  <!-- Setting the environment dynamically -->
+  // Setting the environment dynamically
+  // IMPORTANT Make sure you replace the client ID at the end with your own and the redirect URI with the one you submitted in the I.AM
+  // Connect documentation
   const keycloak = getKeycloakConfigurationForEnv();
   keycloak.init({onLoad: 'login-required', checkLoginIframe: false}).then(function (authenticated) {
-    <!-- Initialization of the authentication library -->
-    <!-- Creation of the custom element -->
+    // Initialization of the authentication library
+    // Creation of the custom element
     const create = document.createElement('nihdi-referral-prescription-create');
-    <!-- Setting the intent input parameter -->
+    // Setting the intent input parameter
     create.intent = params.get('intent') || 'order';  // By default, setting it as 'order'
-    <!-- Input for the patient SSIN -->
+    // Input for the patient SSIN
     create.patientSsin = params.get('ssin');
-    <!-- Input for the language -->
+    // Input for the language
     create.lang = navigator.language.includes('nl') || navigator.language.includes('fr') ? navigator.language : 'fr-BE';
-    <!-- Callback method to get a token for the authentication library -->
+    // Callback method to get a token for the authentication library
     create.getToken = () => Promise.resolve(keycloak.token);
-    <!-- Listener function to get feedback from the Web Component after the prescription has been successfully created -->
+    // Listener function to get feedback from the Web Component after the prescription has been successfully created
     create.addEventListener('prescriptionsCreated', () => {
       document.body.removeChild(create);
       setTimeout(() => {
         alert('Prescription(s) were created. Refresh to start again.');
       }, 100);
     });
-    <!-- Adding the custom element to the HTML body -->
+    // Adding the custom element to the HTML body
     document.body.append(create);
   }).catch(function () {
     alert('failed to initialize');


### PR DESCRIPTION
In order to be able to run the example, some changes needed to be made to the code. I made these here so that it will be easier for others to get the example up and running.
* Replaced CSS en JS links with links to the actual files at wwwacc.referral-prescription. This is needed because the files depend on other files that are present in that location.
* Added required Keycloack package (latest version 25 because version 26 does not work in this application).
* Corrected HTML style comments <!-- --> to Javacript style comments //

The following changes were made for convenience, so that users can see more easily which parameters they need to configure.
* Made Auth URI, realm and client ID input parameters of getKeycloakConfigurationForEnv so that all parameters that users need to adjust to configure the example are in one place and users can see some example values to make it easier to understand how to use these.
* Added comment with some explanation about client ID and redirect URI.